### PR TITLE
Redefine the 0b searchbins and add convenient scripts

### DIFF
--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/findMissingBins.sh
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/findMissingBins.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Get a list of all missing bins in target output directory
+ls ${1}/grid/ | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_grid.md
+ls ${1}/scan/ | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_scan.md
+ls ${1}/grid-dilep/ | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_grid-dilep.md
+
+# List all current search bins
+python searchBins_0b_with_NW.py | sort | uniq > searchBins.md
+
+# Produce a file with only the missing bins which can be read in by searchBins.py as a missingBins list which delets all bins from the cutDict to only produce the missing bins
+grep -v -x -f producedBins_grid.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_grid.md
+grep -v -x -f producedBins_scan.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_scan.md
+grep -v -x -f producedBins_grid-dilep.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_grid-dilep.md

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/makeBinYields_0b.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/makeBinYields_0b.py
@@ -8,13 +8,13 @@ import time
 
 ## Trees -- skimmed with trig_base
 
-Tdir = ["SampLinks2016/"] #important needs this format
+Tdir = ["SampLinks2016_V2/"] #important needs this format
 # MC
-mcFTdir = "SampLinks2016/Friends/"
-sigFTdir = "SampLinks2016/Friends/"
+mcFTdir = "SampLinks2016_V2/Friends/"
+sigFTdir = "SampLinks2016_V2/Friends/"
 
 # new data
-dataFTdir = "SampLinks2016/Friends/"
+dataFTdir = "SampLinks2016_V2/Friends/"
 
 
 
@@ -32,7 +32,7 @@ def addOptions(options):
     options.friendTreesData = [("sf/t",dataFTdir+"/evVarFriend_{cname}.root")]
     options.tree = "treeProducerSusySingleLepton"
 
-    print "????",options.path
+    #print "????",options.path
     # extra options
     options.doS2V = True
     options.weight = True

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/plotMcPredict_0b.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/plotMcPredict_0b.py
@@ -60,7 +60,15 @@ if __name__ == "__main__":
     signalMask = signalBasename.replace("*","X_")
 
     ## Create Yield Storage
-    yds = yp.YieldStore("lepYields")
+    lep = "lep"
+    dataString = "data_QCDsubtr"
+    print pattern.split("/")
+    print pattern.split("/")[2]
+    print "WJets" in pattern.split("/")[2]
+    if "WJets" in pattern.split("/")[2]:
+        lep = "mu"
+        data = "data"
+    yds = yp.YieldStore(lep + "Yields")
     yds.addFromFiles(pattern,("lep","sele"))
     yds.showStats()
 
@@ -72,8 +80,6 @@ if __name__ == "__main__":
     mcSamps = ['VV','DY','TTV','SingleT','TTJets','WJets']
     #mcSamps = ['VV','DY','TTV','SingleT','WJets','TTsemiLep', 'TTdiLep']
     signalSamples = ['T5qqqqWW_Scan_mGo1500_mLSP1000', 'T5qqqqWW_Scan_mGo1900_mLSP100']
-    #signalSamples = ['T5qqqqWW_Scan_mGo1500_mLSP1000', 'T5qqqqWW_Scan_mGo1900_mLSP100', 'T5qqqqWW_Scan_mGo2100_mLSP1800', 'T5qqqqWW_Scan_mGo1050_mLSP900']
-    #signalSamples = ['T5qqqqWW_Scan_mGo1500_mLSP1000', 'T5qqqqWW_Scan_mGo1900_mLSP100', 'T5qqqqWW_Scan_mGo2150_mLSP1750', 'T5qqqqWW_Scan_mGo2100_mLSP1800', 'T5qqqqWW_Scan_mGo2150_mLSP1800', 'T5qqqqWW_Scan_mGo1050_mLSP900', 'T5qqqqWW_Scan_mGo1800_mLSP200', 'T5qqqqWW_Scan_mGo2400_mLSP1400', 'T5qqqqWW_Scan_mGo2550_mLSP200']
 
     # Category
     cat = "CR_MB"
@@ -85,10 +91,9 @@ if __name__ == "__main__":
     #for cat in cats:
 
     # Totals
-    hDataPred = yp.makeSampHisto(yds,"data_QCDsubtr",cat,"Data_prediction"); hDataPred.SetTitle("Data (Pred)")
-
-    hData = yp.makeSampHisto(yds,"data_QCDsubtr",cat,"Data"); hData.SetTitle("Data")
-    hMCPred = yp.makeSampHisto(yds,"background_QCDsubtr",cat,"MC_expectation"); hMCPred.SetTitle("MC (Exp)")
+    hDataPred = yp.makeSampHisto(yds,dataString,cat,"Data_prediction"); hDataPred.SetTitle("Data (Pred)")
+    hData = yp.makeSampHisto(yds,dataString,cat,"Data"); hData.SetTitle("Data")
+    hMCPred = yp.makeSampHisto(yds,"EWK",cat,"MC_expectation"); hMCPred.SetTitle("MC (Exp)")
 
     # Ratio
     #ratio = yp.getRatio(hTotal,hDataPred)

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/searchBins_0b_with_NW.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/searchBins_0b_with_NW.py
@@ -48,6 +48,20 @@ binsLepCharge = {}
 binsLepCharge['pos'] = ('Lep_pdgId < 0', '+1')
 binsLepCharge['neg'] = ('Lep_pdgId > 0', '-1')
 
+# List of missing bins to only reprocces remove all bins which do not match any substring given in missingBins
+# e.g. missingBins = ["LT3", "NJ34"] would include all bins that use LT3 or NJ34
+# if list is empty, all bins will be produced
+
+missingBins = [
+]
+
+doMissingBinsOnly = True
+#filename = "missingBins_scan.md"
+filename = "missingBins_grid.md"
+#filename = "missingBins_grid-dilep.md"
+if doMissingBinsOnly:
+    with open(filename) as missingBinsFile:
+        missingBins = missingBinsFile.read().splitlines()
 
 def getSRcut(nj_bin, lt_bin, sr_bin, blinded):
 
@@ -115,32 +129,36 @@ for nj_bin in ['NJ34_forWJets']:
     for lep_charge in ['neg', 'pos']:
         charge_sel = binsLepCharge[lep_charge][0]
 
-        for nw_bin in ['NW0','NW0i','NW1i']:
-            nw_cut = binsNW[nw_bin][0]
+        for lt_bin in ['LT1','LT2','LT3','LT4i']:
+            lt_cut = binsLT[lt_bin][0]
+            htbins = []
 
-            for lt_bin in ['LT1','LT2','LT3','LT4i']:
-                lt_cut = binsLT[lt_bin][0]
-                htbins = []
+            lt_tmp = lt_bin
+            lt_tmpCut = lt_cut
 
-                lt_tmp = lt_bin
-                lt_tmpCut = lt_cut
+            if lt_bin in ['LT1', 'LT2']:
+                htbins+= ['HT0', 'HT1i', 'HT02', 'HT2i']
 
-                if lt_bin in ['LT1', 'LT2']:
-                    htbins+= ['HT0', 'HT1i', 'HT02', 'HT2i']
+            elif lt_bin in ['LT3']:
+                htbins+= ['HT0', 'HT1', 'HT03', 'HT3i']
+            elif lt_bin in ['LT4i']:
+                htbins+= ['HT03', 'HT3i']
 
-                elif lt_bin in ['LT3', 'LT4i']:
-                    htbins+= ['HT0', 'HT1', 'HT03', 'HT3i']
+            for ht_bin in htbins:
+                ht_cut =binsHT[ht_bin][0]
 
-                for ht_bin in htbins:
-                    ht_cut =binsHT[ht_bin][0]
+                nwbins = []
+                if lt_bin == "LT2" and ht_bin == "HT2i":
+                    nwbins = ["NW0", "NW0i"]
+                elif lt_bin == "LT3" and ht_bin == "HT3i":
+                    nwbins = ["NW0", "NW0i"]
+                elif lt_bin == "LT4i" and ht_bin == "HT3i":
+                    nwbins = ["NW0", "NW0i"]
+                else:
+                    nwbins = ['NW0', 'NW1i']
 
-                    if lt_bin == 'LT3' and ht_bin == 'HT3i':
-                        lt_bin = 'LT3i'
-                        lt_cut = binsLT[lt_bin][0]
-                    elif lt_bin == 'LT4i' and ht_bin == 'HT0' and nw_bin == 'NW0':
-                        lt_bin = 'LT3i'
-                        lt_cut = binsLT[lt_bin][0]
-
+                for nw_bin in nwbins:
+                    nw_cut = binsNW[nw_bin][0]
 
                     binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,lep_charge)
                     cutDictf34[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",lep_charge,charge_sel)]
@@ -167,38 +185,42 @@ for nj_bin in ['NJ45_forTTJets']:
     for nb_bin in ['NB0', 'NB1i']:
         nb_cut = binsNB[nb_bin][0]
 
-        for nw_bin in ['NW0','NW0i','NW1i']:
-            nw_cut = binsNW[nw_bin][0]
 
-            for lt_bin in ['LT1','LT2','LT3','LT4i']:
-                lt_cut = binsLT[lt_bin][0]
-                htbins = []
+        for lt_bin in ['LT1','LT2','LT3','LT4i']:
+            lt_cut = binsLT[lt_bin][0]
+            htbins = []
 
-                lt_tmp = lt_bin
-                lt_tmpCut = lt_cut
+            lt_tmp = lt_bin
+            lt_tmpCut = lt_cut
 
-                if lt_bin in ['LT1', 'LT2']:
-                   htbins+= ['HT0', 'HT1i', 'HT02', 'HT2i']
+            if lt_bin in ['LT1', 'LT2']:
+               htbins+= ['HT0', 'HT1i', 'HT02', 'HT2i']
 
-                elif lt_bin in ['LT3', 'LT4i']:
-                    htbins+= ['HT0', 'HT1', 'HT03', 'HT3i']
+            elif lt_bin in ['LT3']:
+                htbins+= ['HT0', 'HT1', 'HT03', 'HT3i']
+            elif lt_bin in ['LT4i']:
+                htbins+= ['HT03', 'HT3i']
 
-                for ht_bin in htbins:
-                    ht_cut =binsHT[ht_bin][0]
+            for ht_bin in htbins:
+                ht_cut =binsHT[ht_bin][0]
+
+                nwbins = []
+                if lt_bin == "LT4i" and ht_bin == "HT3i" and nb_bin == "NB1i":
+                    nwbins = ["NW0", "NW0i"]
+                elif lt_bin == "LT2" and ht_bin == "HT2i":
+                    nwbins = ["NW0", "NW0i", "NW1i"]
+                elif lt_bin == "LT3" and ht_bin == "HT3i":
+                    nwbins = ["NW0", "NW0i", "NW1i"]
+                elif lt_bin == "LT4i" and ht_bin == "HT3i":
+                    nwbins = ["NW0", "NW0i", "NW1i"]
+                else:
+                    nwbins = ['NW0', 'NW1i']
+
+                for nw_bin in nwbins:
+                    nw_cut = binsNW[nw_bin][0]
 
                     binname = "%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin)
                     cutDictf45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut)]
-
-                    if lt_bin == 'LT3' and ht_bin == 'HT3i':
-                        lt_bin = 'LT3i'
-                        lt_cut = binsLT[lt_bin][0]
-                        binname = "%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin)
-                        cutDictf45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut)]
-                    elif lt_bin == 'LT4i' and ht_bin == 'HT0' and nw_bin == 'NW0':
-                        lt_bin = 'LT3i'
-                        lt_cut = binsLT[lt_bin][0]
-                        binname = "%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin)
-                        cutDictf45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut)]
 
                     lt_bin = lt_tmp
                     lt_cut = lt_tmpCut
@@ -209,18 +231,6 @@ for nj_bin in ['NJ45_forTTJets']:
                         binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,sr_bin)
                         cutDictSR45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",sr_bin,sr_cut)]
 
-                        #To account for missing WJets bins
-                        if lt_bin == 'LT3' and ht_bin == 'HT3i':
-                            lt_bin = 'LT3i'
-                            lt_cut = binsLT[lt_bin][0]
-                            binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,sr_bin)
-                            cutDictSR45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",sr_bin,sr_cut)]
-                        elif lt_bin == 'LT4i' and ht_bin == 'HT0' and nw_bin == 'NW0':
-                            lt_bin = 'LT3i'
-                            lt_cut = binsLT[lt_bin][0]
-                            binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,sr_bin)
-                            cutDictSR45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",sr_bin,sr_cut)]
-
                     lt_bin = lt_tmp
                     lt_cut = lt_tmpCut
 
@@ -228,18 +238,6 @@ for nj_bin in ['NJ45_forTTJets']:
                         cr_cut = getSRcut(nj_bin, lt_bin, cr_bin, blinded)[0]
                         binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,cr_bin)
                         cutDictCR45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",cr_bin,cr_cut)]
-
-                        #To account for missing WJets bins
-                        if lt_bin == 'LT3' and ht_bin == 'HT3i':
-                            lt_bin = 'LT3i'
-                            lt_cut = binsLT[lt_bin][0]
-                            binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,cr_bin)
-                            cutDictCR45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",cr_bin,cr_cut)]
-                        elif lt_bin == 'LT4i' and ht_bin == 'HT0' and nw_bin == 'NW0':
-                            lt_bin = 'LT3i'
-                            lt_cut = binsLT[lt_bin][0]
-                            binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,cr_bin)
-                            cutDictCR45[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",cr_bin,cr_cut)]
 
                     lt_bin = lt_tmp
                     lt_cut = lt_tmpCut
@@ -264,10 +262,10 @@ for nj_bin in ['NJ5_forWJets']:
                 if lt_bin in ['LT1', 'LT2']:
                     htbins+= ['HT0', 'HT1i']
 
-                elif lt_bin in ['LT3', 'LT4i']:
+                elif lt_bin in ['LT3']:
                     htbins+= ['HT0', 'HT1', 'HT3i']
-                #elif lt_bin in ['LT4i']:
-                    #htbins+= ['HT03', 'HT3i']
+                elif lt_bin in ['LT4i']:
+                    htbins+= ['HT03', 'HT3i']
 
                 for ht_bin in htbins:
                     ht_cut =binsHT[ht_bin][0]
@@ -305,10 +303,10 @@ for nj_bin in ['NJ5_forTTJets']:
             if lt_bin in ['LT1', 'LT2']:
                 htbins+= ['HT0', 'HT1i']
 
-            elif lt_bin in ['LT3', 'LT4i']:
+            elif lt_bin in ['LT3']:
                 htbins+= ['HT0', 'HT1', 'HT3i']
-            #elif lt_bin in ['LT4i']:
-                #htbins+= ['HT03', 'HT3i']
+            elif lt_bin in ['LT4i']:
+                htbins+= ['HT03', 'HT3i']
 
             for ht_bin in htbins:
                 ht_cut =binsHT[ht_bin][0]
@@ -435,7 +433,8 @@ for nj_bin in ['NJ8i_forWJets']:
                 ht_cut =binsHT[ht_bin][0]
 
                 nwbins = []
-                if lt_bin in ['LT4i'] and ht_bin == 'HT03':
+                #if lt_bin in ['LT4i'] and (ht_bin == 'HT03' or ht_bin == "HT3i"):
+                if lt_bin in ['LT4i'] and (ht_bin == "HT3i"):
                     nwbins = ['NW0i']
                 else:
                     nwbins = ['NW0','NW1i']
@@ -479,7 +478,7 @@ for nj_bin in ['NJ8i_forTTJets']:
             ht_cut =binsHT[ht_bin][0]
 
             nwbins = []
-            if lt_bin in ['LT4i'] and ht_bin == 'HT03':
+            if lt_bin in ['LT4i'] and (ht_bin == "HT3i"):
                 nwbins = ['NW0i']
             else:
                 nwbins = ['NW0','NW1i']
@@ -503,13 +502,8 @@ for nj_bin in ['NJ8i_forTTJets']:
                     binname = "%s_%s_%s_%s_%s_%s" %(lt_bin,ht_bin,nb_bin,nj_bin,nw_bin,cr_bin)
                     cutDictCR8[binname] = [("base",lt_bin,lt_cut),("base",ht_bin,ht_cut),("base",nb_bin,nb_cut),("base",nj_bin,nj_cut),("base",nw_bin,nw_cut),("base",cr_bin,cr_cut)]
 
-# List of missing bins to only reprocces remove all bins which do not match any substring given in missingBins
-# e.g. missingBins = ["LT3", "NJ34"] would include all bins that use LT3 or NJ34
-missingBins = [
-]
 
 if missingBins != []:
-
     for cutDictf, cutDictSR, cutDictCR in [(cutDictf34, cutDictSR34, cutDictCR34), (cutDictf45, cutDictSR45, cutDictCR45), (cutDictf5, cutDictSR5, cutDictCR5), (cutDictf67, cutDictSR67, cutDictCR67), (cutDictf8, cutDictSR8, cutDictCR8)]:
         for bin in cutDictf.keys():
             keepBin = False
@@ -556,9 +550,9 @@ if __name__=="__main__":
         print(bin)
 
     #print "NJ45 TTJets"
-    for bin in cutDictf45.keys():
+    for bin in cutDictSR45.keys():
         print(bin)
-    for bin in cutDictf45.keys():
+    for bin in cutDictCR45.keys():
         print(bin)
 
     #print "Main Band Bins!"

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/searchBins_0b_with_NW.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/searchBins_0b_with_NW.py
@@ -55,7 +55,7 @@ binsLepCharge['neg'] = ('Lep_pdgId > 0', '-1')
 missingBins = [
 ]
 
-doMissingBinsOnly = True
+doMissingBinsOnly = False
 #filename = "missingBins_scan.md"
 filename = "missingBins_grid.md"
 #filename = "missingBins_grid-dilep.md"

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/yieldClass_0b.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/yieldClass_0b.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os, glob, sys, math
-from searchBinsMoriond17_Pantelis_BaseLine_T5qqqqWW_with_NW_V5 import *
+from searchBins_0b_with_NW import *
 from ROOT import *
 from readYields import getLepYield, getScanYields
 #helper function maybe move somewhere else
@@ -103,7 +103,6 @@ class YieldStore:
         binName = bfname[:bfname.find(".")]
         binName = binName.replace("_SR","")
         #binName = binName.replace(".merge.root","")
-        #print binName
 
         # get list of dirs
         dirList = [dirKey.ReadObj() for dirKey in gDirectory.GetListOfKeys() if dirKey.IsFolder() == 1]
@@ -185,6 +184,7 @@ class YieldStore:
 
         # find files matching pattern
         fileList = glob.glob(pattern+"*.root")
+
         nFiles = len(fileList)
 
         print "## Starting to add yields for %s from %i files like " %(self.name,nFiles) + pattern + ": ", ; sys.stdout.flush()
@@ -239,8 +239,13 @@ class YieldStore:
             return dct
             #return self.yields[samp][cat]
         else:
-            print 'Either {} is not in {} or {} is not in {}. Something\'s wrong here.'.format(samp, self.samples, cat, self.categories)
-            return 0
+            #print 'Either {} is not in {} or {} is not in {}. Something\'s wrong here.'.format(samp, self.samples, cat, self.categories)
+            print "While getting the sample dict, something went wrong!"
+            print "Your sample {} is not in the list of samples!".format(samp) * (samp not in self.samples)
+            print "Your category {} is not in the list of categories {}!".format(cat, self.categories) * (cat not in self.categories)
+            print "Exiting Now!"
+            #return 0
+            exit()
 
     def getSampsDict(self,samp,cats = []):
 


### PR DESCRIPTION
A few bins in the MB were redifined and I also added a shell script that searches the output of your output directory and looks for misisng bins.
I also removed SB bins which are not used, making the plots a little bit less crowded.

searchBins_0b_with_NW.py now has a flag (which you have to change manually) to read in from one of the missing bins file and only produce the failed output. All this has to be done manually (uncommenting the relevant lines and so on), so it is not perfect but better than just resubmitting everything if just a hand full of jobs have failed.