### PR TITLE
104 x ba

### DIFF
--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/findMissingBins.sh
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/findMissingBins.sh
@@ -1,13 +1,11 @@
 #!/bin/sh
-# Get a list of all missing bins in target output directory
-ls ${1}/grid/ | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_grid.md
-ls ${1}/scan/ | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_scan.md
-ls ${1}/grid-dilep/ | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_grid-dilep.md
-
+input=$1
+year=$2
 # List all current search bins
 python searchBins_0b_with_NW.py | sort | uniq > searchBins.md
-
-# Produce a file with only the missing bins which can be read in by searchBins.py as a missingBins list which delets all bins from the cutDict to only produce the missing bins
-grep -v -x -f producedBins_grid.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_grid.md
-grep -v -x -f producedBins_scan.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_scan.md
-grep -v -x -f producedBins_grid-dilep.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_grid-dilep.md
+# Get a list of all missing bins in target output directory
+for dir in grid scan grid-dilep;
+do
+	ls ${input}/${dir} | grep ".root" | sed "s@.yields.root@@g" |sort |uniq > producedBins_${dir}_${year}.md
+	grep -v -x -f producedBins_${dir}_${year}.md searchBins.md | sed "s@_SR@@g" | sed "s@_CR@@g" | sort | uniq > missingBins_${dir}_${year}.md
+done

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2017
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2017
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+
+if [ -z "${1}" ]; then
+    echo Please specify outputfolder as positional argument.
+    exit
+fi
+
+lumi=41.9
+outputdir="${1}"
+
+
+#### Signal
+#./makeBinYields_0b_2017.py \
+#    --mca mca/2017/mca-Fall17_Signal_0b.txt \
+#    --signal \
+#    -v 2 \
+#    -l "${lumi}" \
+#    -b \
+#    --od "${outputdir}"/scan
+
+###Background
+#./makeBinYields_0b_2017.py \
+#    --mca mca/2017/mca-Fall17_0b.txt \
+#    --grid \
+#    -v 2 \
+#    -l "${lumi}" \
+#    -b \
+#    --od "${outputdir}"/grid
+
+#### Background with dilepton nJet correction
+#./makeBinYields_0b_2017.py \
+#    --mca mca/2017/mca-Fall17_0b_dilep-corr.txt \
+#    --grid \
+#    -v 2 \
+#    -l "${lumi}" \
+#    -b \
+#    --od "${outputdir}"/grid-dilep
+
+#### Systematic: dilepton constant
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/DLConst/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_DLConst
+###
+#### Systematic: dilepton slope
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/DLSlope/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_DLSlope
+###
+#### Systematic: JEC
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/JEC/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_JEC
+###
+##### Systematic: PDF
+./makeBinYields.py \
+    --mca ../systs/PDFUnc-RMS/mca-Fall17_Moriond17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_PDFUnc-RMS
+###
+##### Systematic: scale match
+####./makeBinYields.py \
+####    --mca ../systs/ScaleMatchVar/mca-Fall17_Moriond17.txt \
+####    --grid \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+####    --od "${outputdir}"/syst_ScaleMatchVar
+###
+###
+#### Systematic: W polarization
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/Wpol/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_Wpol
+###
+#### Systematic: W cross section
+###./makeBinYields.py \
+###    --mca ../systs/2017/Wxsec/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_Wxsec
+###
+#### Systematic: b-tagging heavy flavour
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/btagHF/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_btagHF
+###
+#### Systematic: b-tagging
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/btagLF/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_btagLF
+###
+#### Systematic: lepton SF
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/lepSF/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_lepSF
+###
+#### Systematic: pileup
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/PU/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_PU
+###
+#### Systematic: TTV cross section
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/TTVxsec/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_TTVxsec
+###
+#### Systematic: TT cross section
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/TTxsec/mca-Fall17.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/syst_TTxsec
+###
+##### Systematic: nISR reweighting
+####./makeBinYields.py \
+####    --mca ../systs/2017_EXT/nISR/mca-Fall17.txt \
+####    --grid \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+####    --od "${outputdir}"/syst_nISR
+###
+#### Signal systematic: Gluino ISR
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/signal/ISR/mca-Fall17_Signal.txt \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/signal_ISR
+###
+#### Signal systematic: JEC
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/signal/JEC/mca-Fall17_Signal.txt  \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/signal_JEC
+###
+#### Signal systematic: btag heavy flavour
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/signal/btagHF/mca-Fall17_Signal.txt  \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/signal_btagHF
+###
+#### Signal systematic: btag light flavour
+###./makeBinYields.py \
+###    --mca ../systs/2017_EXT/signal/btagLF/mca-Fall17_Signal.txt  \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --od "${outputdir}"/signal_btagLF
+###
+###
+###
+###
+###
+###
+#### does not work out of the box, because the new signal samples are not in
+#### the same place as the old ones (yet) and the paths are hardcoded in
+#### makeBinYields
+##### Signal systematic: scale variation
+####./makeBinYields.py \
+####    --mca ../systs/signal/scale/mca-Fall17_Signal_forMoriond17.txt  \
+####    --signal \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+####    --od "${outputdir}"/signal_scale
+###
+##### Signal systematic: pileup
+####./makeBinYields.py \
+####    --mca ../systs/signal/PU/mca-Fall17_Signal_forMoriond17.txt  \
+####    --signal \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+####    --od "${outputdir}"/signal_PU
+###

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2017
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2017
@@ -9,239 +9,179 @@ lumi=41.9
 outputdir="${1}"
 
 
-#### Signal
-#./makeBinYields_0b_2017.py \
-#    --mca mca/2017/mca-Fall17_Signal_0b.txt \
-#    --signal \
-#    -v 2 \
-#    -l "${lumi}" \
-#    -b \
-#    --od "${outputdir}"/scan
+# Signal
+./makeBinYields_0b_2017.py \
+    --mca mca/2017/mca-Fall17_Signal_0b.txt \
+    --signal \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/scan
 
-###Background
-#./makeBinYields_0b_2017.py \
-#    --mca mca/2017/mca-Fall17_0b.txt \
-#    --grid \
-#    -v 2 \
-#    -l "${lumi}" \
-#    -b \
-#    --od "${outputdir}"/grid
+#Background
+./makeBinYields_0b_2017.py \
+    --mca mca/2017/mca-Fall17_0b.txt \
+    --grid \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/grid
 
-#### Background with dilepton nJet correction
-#./makeBinYields_0b_2017.py \
-#    --mca mca/2017/mca-Fall17_0b_dilep-corr.txt \
-#    --grid \
-#    -v 2 \
-#    -l "${lumi}" \
-#    -b \
-#    --od "${outputdir}"/grid-dilep
+# Background with dilepton nJet correction
+./makeBinYields_0b_2017.py \
+    --mca mca/2017/mca-Fall17_0b_dilep-corr.txt \
+    --grid \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/grid-dilep
 
-#### Systematic: dilepton constant
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/DLConst/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_DLConst
-###
-#### Systematic: dilepton slope
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/DLSlope/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_DLSlope
-###
-#### Systematic: JEC
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/JEC/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_JEC
-###
-##### Systematic: PDF
+# Systematic: dilepton constant
 ./makeBinYields.py \
-    --mca ../systs/PDFUnc-RMS/mca-Fall17_Moriond17.txt \
+    --mca ../systs/2017/DLConst/mca-Fall17.txt \
     --grid \
     --systs True \
     -v 2 \
     -l "${lumi}" \
     -b \
-    --od "${outputdir}"/syst_PDFUnc-RMS
-###
-##### Systematic: scale match
-####./makeBinYields.py \
-####    --mca ../systs/ScaleMatchVar/mca-Fall17_Moriond17.txt \
-####    --grid \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-####    --od "${outputdir}"/syst_ScaleMatchVar
-###
-###
-#### Systematic: W polarization
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/Wpol/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_Wpol
-###
-#### Systematic: W cross section
-###./makeBinYields.py \
-###    --mca ../systs/2017/Wxsec/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_Wxsec
-###
-#### Systematic: b-tagging heavy flavour
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/btagHF/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_btagHF
-###
-#### Systematic: b-tagging
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/btagLF/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_btagLF
-###
-#### Systematic: lepton SF
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/lepSF/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_lepSF
-###
-#### Systematic: pileup
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/PU/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_PU
-###
-#### Systematic: TTV cross section
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/TTVxsec/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_TTVxsec
-###
-#### Systematic: TT cross section
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/TTxsec/mca-Fall17.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/syst_TTxsec
-###
-##### Systematic: nISR reweighting
-####./makeBinYields.py \
-####    --mca ../systs/2017_EXT/nISR/mca-Fall17.txt \
-####    --grid \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-####    --od "${outputdir}"/syst_nISR
-###
-#### Signal systematic: Gluino ISR
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/signal/ISR/mca-Fall17_Signal.txt \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/signal_ISR
-###
-#### Signal systematic: JEC
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/signal/JEC/mca-Fall17_Signal.txt  \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/signal_JEC
-###
-#### Signal systematic: btag heavy flavour
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/signal/btagHF/mca-Fall17_Signal.txt  \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/signal_btagHF
-###
-#### Signal systematic: btag light flavour
-###./makeBinYields.py \
-###    --mca ../systs/2017_EXT/signal/btagLF/mca-Fall17_Signal.txt  \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --od "${outputdir}"/signal_btagLF
-###
-###
-###
-###
-###
-###
-#### does not work out of the box, because the new signal samples are not in
-#### the same place as the old ones (yet) and the paths are hardcoded in
-#### makeBinYields
-##### Signal systematic: scale variation
-####./makeBinYields.py \
-####    --mca ../systs/signal/scale/mca-Fall17_Signal_forMoriond17.txt  \
-####    --signal \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-####    --od "${outputdir}"/signal_scale
-###
-##### Signal systematic: pileup
-####./makeBinYields.py \
-####    --mca ../systs/signal/PU/mca-Fall17_Signal_forMoriond17.txt  \
-####    --signal \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-####    --od "${outputdir}"/signal_PU
-###
+    --od "${outputdir}"/syst_DLConst
+
+# Systematic: dilepton slope
+./makeBinYields.py \
+    --mca ../systs/2017/DLSlope/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_DLSlope
+
+# Systematic: JEC
+./makeBinYields.py \
+    --mca ../systs/2017/JEC/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_JEC
+
+# Systematic: W polarization
+./makeBinYields.py \
+    --mca ../systs/2017/Wpol/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_Wpol
+
+# Systematic: W cross section
+./makeBinYields.py \
+    --mca ../systs/2017/Wxsec/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_Wxsec
+
+# Systematic: b-tagging heavy flavour
+./makeBinYields.py \
+    --mca ../systs/2017/btagHF/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_btagHF
+
+# Systematic: b-tagging
+./makeBinYields.py \
+    --mca ../systs/2017/btagLF/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_btagLF
+
+# Systematic: lepton SF
+./makeBinYields.py \
+    --mca ../systs/2017/lepSF/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_lepSF
+
+# Systematic: pileup
+./makeBinYields.py \
+    --mca ../systs/2017/PU/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_PU
+
+# Systematic: TTV cross section
+./makeBinYields.py \
+    --mca ../systs/2017/TTVxsec/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_TTVxsec
+
+# Systematic: TT cross section
+./makeBinYields.py \
+    --mca ../systs/2017/TTxsec/mca-Fall17.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/syst_TTxsec
+
+# Signal systematic: Gluino ISR
+./makeBinYields.py \
+    --mca ../systs/2017/signal/ISR/mca-Fall17_Signal.txt \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/signal_ISR
+
+# Signal systematic: JEC
+./makeBinYields.py \
+    --mca ../systs/2017/signal/JEC/mca-Fall17_Signal.txt  \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/signal_JEC
+
+# Signal systematic: btag heavy flavour
+./makeBinYields.py \
+    --mca ../systs/2017/signal/btagHF/mca-Fall17_Signal.txt  \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/signal_btagHF
+
+# Signal systematic: btag light flavour
+./makeBinYields.py \
+    --mca ../systs/2017/signal/btagLF/mca-Fall17_Signal.txt  \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --od "${outputdir}"/signal_btagLF

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2018
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2018
@@ -9,27 +9,27 @@ lumi=59.74
 outputdir="${1}"
 
 
-## Signal
-#./makeBinYields_0b_2018.py \
-#    --mca mca/2018/mca-Autumn18_Signal_0b.txt \
-#    --signal \
-#    -v 2 \
-#    -l "${lumi}" \
-#    -b \
-#    --cuts trig_base_HEM.txt \
-#    --od "${outputdir}"/scan
-#
-### Background
-#./makeBinYields_0b_2018.py \
-#    --mca mca/2018/mca-Autumn18_0b.txt \
-#    --grid \
-#    -v 2 \
-#    -l "${lumi}" \
-#    -b \
-#    --cuts trig_base_HEM.txt \
-#    --od "${outputdir}"/grid
+# Signal
+./makeBinYields_0b_2018.py \
+    --mca mca/2018/mca-Autumn18_Signal_0b.txt \
+    --signal \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/scan
 
-### Background with dilepton nJet correction
+# Background
+./makeBinYields_0b_2018.py \
+    --mca mca/2018/mca-Autumn18_0b.txt \
+    --grid \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/grid
+
+# Background with dilepton nJet correction
 ./makeBinYields_0b_2018.py \
     --mca mca/2018/mca-Autumn18_0b_dilep-corr.txt \
     --grid \
@@ -38,234 +38,168 @@ outputdir="${1}"
     -b \
     --cuts trig_base_HEM.txt \
     --od "${outputdir}"/grid-dilep
-###
-#### Systematic: dilepton constant
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/DLConst/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_DLConst
-###
-#### Systematic: dilepton slope
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/DLSlope/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_DLSlope
-###
-#### Systematic: JEC
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/JEC/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_JEC
-###
-##### Systematic: PDF
-####./makeBinYields.py \
-####    --mca ../systs/PDFUnc-RMS/mca-Autumn18_Moriond17.txt \
-####    --grid \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-###    --cuts trig_base_HEM.txt \
-####    --od "${outputdir}"/syst_PDFUnc-RMS
-###
-##### Systematic: scale match
-####./makeBinYields.py \
-####    --mca ../systs/ScaleMatchVar/mca-Autumn18_Moriond17.txt \
-####    --grid \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-###    --cuts trig_base_HEM.txt \
-####    --od "${outputdir}"/syst_ScaleMatchVar
-###
-###
-#### Systematic: W polarization
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/Wpol/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_Wpol
-###
-#### Systematic: W cross section
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/Wxsec/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_Wxsec
-###
-#### Systematic: b-tagging heavy flavour
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/btagHF/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_btagHF
-###
-#### Systematic: b-tagging
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/btagLF/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_btagLF
-###
-#### Systematic: lepton SF
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/lepSF/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_lepSF
-###
-#### Systematic: pileup
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/PU/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_PU
-###
-#### Systematic: TTV cross section
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/TTVxsec/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_TTVxsec
-###
-#### Systematic: TT cross section
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/TTxsec/mca-Autumn18.txt \
-###    --grid \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/syst_TTxsec
-###
-##### Systematic: nISR reweighting
-####./makeBinYields.py \
-####    --mca ../systs/2018_EXT/nISR/mca-Autumn18.txt \
-####    --grid \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-###    --cuts trig_base_HEM.txt \
-####    --od "${outputdir}"/syst_nISR
-###
-###
-#### Signal systematic: Gluino ISR
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/signal/ISR/mca-Autumn18_Signal.txt \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/signal_ISR
-###
-#### Signal systematic: JEC
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/signal/JEC/mca-Autumn18_Signal.txt  \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/signal_JEC
-###
-#### Signal systematic: btag heavy flavour
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/signal/btagHF/mca-Autumn18_Signal.txt  \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/signal_btagHF
-###
-#### Signal systematic: btag light flavour
-###./makeBinYields.py \
-###    --mca ../systs/2018_EXT/signal/btagLF/mca-Autumn18_Signal.txt  \
-###    --signal \
-###    --systs True \
-###    -v 2 \
-###    -l "${lumi}" \
-###    -b \
-###    --cuts trig_base_HEM.txt \
-###    --od "${outputdir}"/signal_btagLF
-###
-###
-###
-###
-###
-###
-#### does not work out of the box, because the new signal samples are not in
-#### the same place as the old ones (yet) and the paths are hardcoded in
-#### makeBinYields
-##### Signal systematic: scale variation
-####./makeBinYields.py \
-####    --mca ../systs/signal/scale/mca-Autumn18_Signal_forMoriond17.txt  \
-####    --signal \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-###    --cuts trig_base_HEM.txt \
-####    --od "${outputdir}"/signal_scale
-###
-##### Signal systematic: pileup
-####./makeBinYields.py \
-####    --mca ../systs/signal/PU/mca-Autumn18_Signal_forMoriond17.txt  \
-####    --signal \
-####    --systs True \
-####    -v 2 \
-####    -l "${lumi}" \
-####    -b \
-###    --cuts trig_base_HEM.txt \
-####    --od "${outputdir}"/signal_PU
-###
+
+# Systematic: dilepton constant
+./makeBinYields.py \
+    --mca ../systs/2018/DLConst/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_DLConst
+
+# Systematic: dilepton slope
+./makeBinYields.py \
+    --mca ../systs/2018/DLSlope/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_DLSlope
+
+# Systematic: JEC
+./makeBinYields.py \
+    --mca ../systs/2018/JEC/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_JEC
+
+# Systematic: W polarization
+./makeBinYields.py \
+    --mca ../systs/2018/Wpol/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_Wpol
+
+# Systematic: W cross section
+./makeBinYields.py \
+    --mca ../systs/2018/Wxsec/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_Wxsec
+
+# Systematic: b-tagging heavy flavour
+./makeBinYields.py \
+    --mca ../systs/2018/btagHF/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_btagHF
+
+# Systematic: b-tagging
+./makeBinYields.py \
+    --mca ../systs/2018/btagLF/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_btagLF
+
+# Systematic: lepton SF
+./makeBinYields.py \
+    --mca ../systs/2018/lepSF/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_lepSF
+
+# Systematic: pileup
+./makeBinYields.py \
+    --mca ../systs/2018/PU/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_PU
+
+# Systematic: TTV cross section
+./makeBinYields.py \
+    --mca ../systs/2018/TTVxsec/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_TTVxsec
+
+# Systematic: TT cross section
+./makeBinYields.py \
+    --mca ../systs/2018/TTxsec/mca-Autumn18.txt \
+    --grid \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/syst_TTxsec
+
+# Signal systematic: Gluino ISR
+./makeBinYields.py \
+    --mca ../systs/2018/signal/ISR/mca-Autumn18_Signal.txt \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/signal_ISR
+
+# Signal systematic: JEC
+./makeBinYields.py \
+    --mca ../systs/2018/signal/JEC/mca-Autumn18_Signal.txt  \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/signal_JEC
+
+# Signal systematic: btag heavy flavour
+./makeBinYields.py \
+    --mca ../systs/2018/signal/btagHF/mca-Autumn18_Signal.txt  \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/signal_btagHF
+
+# Signal systematic: btag light flavour
+./makeBinYields.py \
+    --mca ../systs/2018/signal/btagLF/mca-Autumn18_Signal.txt  \
+    --signal \
+    --systs True \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/signal_btagLF

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2018
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_0b_2018
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+
+if [ -z "${1}" ]; then
+    echo Please specify outputfolder as positional argument.
+    exit
+fi
+
+lumi=59.74
+outputdir="${1}"
+
+
+## Signal
+#./makeBinYields_0b_2018.py \
+#    --mca mca/2018/mca-Autumn18_Signal_0b.txt \
+#    --signal \
+#    -v 2 \
+#    -l "${lumi}" \
+#    -b \
+#    --cuts trig_base_HEM.txt \
+#    --od "${outputdir}"/scan
+#
+### Background
+#./makeBinYields_0b_2018.py \
+#    --mca mca/2018/mca-Autumn18_0b.txt \
+#    --grid \
+#    -v 2 \
+#    -l "${lumi}" \
+#    -b \
+#    --cuts trig_base_HEM.txt \
+#    --od "${outputdir}"/grid
+
+### Background with dilepton nJet correction
+./makeBinYields_0b_2018.py \
+    --mca mca/2018/mca-Autumn18_0b_dilep-corr.txt \
+    --grid \
+    -v 2 \
+    -l "${lumi}" \
+    -b \
+    --cuts trig_base_HEM.txt \
+    --od "${outputdir}"/grid-dilep
+###
+#### Systematic: dilepton constant
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/DLConst/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_DLConst
+###
+#### Systematic: dilepton slope
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/DLSlope/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_DLSlope
+###
+#### Systematic: JEC
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/JEC/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_JEC
+###
+##### Systematic: PDF
+####./makeBinYields.py \
+####    --mca ../systs/PDFUnc-RMS/mca-Autumn18_Moriond17.txt \
+####    --grid \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+###    --cuts trig_base_HEM.txt \
+####    --od "${outputdir}"/syst_PDFUnc-RMS
+###
+##### Systematic: scale match
+####./makeBinYields.py \
+####    --mca ../systs/ScaleMatchVar/mca-Autumn18_Moriond17.txt \
+####    --grid \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+###    --cuts trig_base_HEM.txt \
+####    --od "${outputdir}"/syst_ScaleMatchVar
+###
+###
+#### Systematic: W polarization
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/Wpol/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_Wpol
+###
+#### Systematic: W cross section
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/Wxsec/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_Wxsec
+###
+#### Systematic: b-tagging heavy flavour
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/btagHF/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_btagHF
+###
+#### Systematic: b-tagging
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/btagLF/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_btagLF
+###
+#### Systematic: lepton SF
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/lepSF/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_lepSF
+###
+#### Systematic: pileup
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/PU/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_PU
+###
+#### Systematic: TTV cross section
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/TTVxsec/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_TTVxsec
+###
+#### Systematic: TT cross section
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/TTxsec/mca-Autumn18.txt \
+###    --grid \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/syst_TTxsec
+###
+##### Systematic: nISR reweighting
+####./makeBinYields.py \
+####    --mca ../systs/2018_EXT/nISR/mca-Autumn18.txt \
+####    --grid \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+###    --cuts trig_base_HEM.txt \
+####    --od "${outputdir}"/syst_nISR
+###
+###
+#### Signal systematic: Gluino ISR
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/signal/ISR/mca-Autumn18_Signal.txt \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/signal_ISR
+###
+#### Signal systematic: JEC
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/signal/JEC/mca-Autumn18_Signal.txt  \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/signal_JEC
+###
+#### Signal systematic: btag heavy flavour
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/signal/btagHF/mca-Autumn18_Signal.txt  \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/signal_btagHF
+###
+#### Signal systematic: btag light flavour
+###./makeBinYields.py \
+###    --mca ../systs/2018_EXT/signal/btagLF/mca-Autumn18_Signal.txt  \
+###    --signal \
+###    --systs True \
+###    -v 2 \
+###    -l "${lumi}" \
+###    -b \
+###    --cuts trig_base_HEM.txt \
+###    --od "${outputdir}"/signal_btagLF
+###
+###
+###
+###
+###
+###
+#### does not work out of the box, because the new signal samples are not in
+#### the same place as the old ones (yet) and the paths are hardcoded in
+#### makeBinYields
+##### Signal systematic: scale variation
+####./makeBinYields.py \
+####    --mca ../systs/signal/scale/mca-Autumn18_Signal_forMoriond17.txt  \
+####    --signal \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+###    --cuts trig_base_HEM.txt \
+####    --od "${outputdir}"/signal_scale
+###
+##### Signal systematic: pileup
+####./makeBinYields.py \
+####    --mca ../systs/signal/PU/mca-Autumn18_Signal_forMoriond17.txt  \
+####    --signal \
+####    --systs True \
+####    -v 2 \
+####    -l "${lumi}" \
+####    -b \
+###    --cuts trig_base_HEM.txt \
+####    --od "${outputdir}"/signal_PU
+###

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_after_0b
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/run_analysis_after_0b
@@ -24,39 +24,43 @@ for folder in "${inputfolder}"/*; do
     if [[ -d "${folder}"/merged/ ]]; then
         continue
     fi
-    ./mergeBins_0b.py "${folder}"
+    ./mergeBins_0b.py "${folder}/LT"
 done
 
 ## Append Rcs kappa
-echo Run appendRcsKappa.py
+echo Run appendRcsKappa_0b.py
 for folder in "${inputfolder}"/*/merged*; do
+    echo $folder
     #Skip signal folder
     if [[ "${folder}" == */scan/* ]]; then
+        echo "scan"
         continue
     fi
     #Predict backgrounds
-    if [[ "${folder}" == */merged/* ]]; then
-        ./appendRcsKappa.py "${folder}"
+    if [[ "${folder}" == */*/merged ]]; then
+        echo ./appendRcsKappa_0b.py "${folder}/LT"
+        ./appendRcsKappa_0b.py "${folder}"
     fi
     #Only do qcd estimate for SB, this is only needed for plotting and calculating Rcs here does not make sense
-    if [[ "${folder}" == */mergedNJ*/* ]]; then
-        ./appendRcsKappa.py "${folder}" --do-qcd
+    if [[ "${folder}" == */*/mergedNJ* ]]; then
+        echo ./appendRcsKappa_0b.py "${folder}/LT" --do-qcd
+        ./appendRcsKappa_0b.py "${folder}" --do-qcd
     fi
 done
 
 
-## Calculate the systematic variations
-## Takes up and down histograms and creates syst histograms
-#echo Run calcSyst.py
-#for folder in "${inputfolder}"/*/merged*; do
-#    if [[ "${folder}" == */scan/* ]] \
-#        || [[ "${folder}" == */grid/* ]] \
-#        || [[ "${folder}" == */grid-dilep/* ]] \
-#        || [[ "${folder}" == */signal_MET/* ]]; then
-#        continue
-#    fi
-#    ./calcSyst.py "${folder}"
-#done
+# Calculate the systematic variations
+# Takes up and down histograms and creates syst histograms
+echo Run calcSyst.py
+for folder in "${inputfolder}"/*/merged*; do
+    if [[ "${folder}" == */scan/* ]] \
+        || [[ "${folder}" == */grid/* ]] \
+        || [[ "${folder}" == */grid-dilep/* ]] \
+        || [[ "${folder}" == */signal_MET/* ]]; then
+        continue
+    fi
+    ./calcSyst.py "${folder}"
+done
 
 ## Write table with systematic variations that is used by makeYieldTables.py
 #echo Run tableSyst.py

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/searchBins_0b_with_NW.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/searchBins_0b_with_NW.py
@@ -49,11 +49,11 @@ missingBins = [
 doMissingBinsOnly = False
 #doMissingBinsOnly = True
 #filename = "missingBins_scan_charge.md"
-filename = "missingBins_grid_charge.md"
+#filename = "missingBins_grid_charge.md"
 #filename = "missingBins_grid-dilep_charge.md"
-if doMissingBinsOnly:
-    with open(filename) as missingBinsFile:
-        missingBins = missingBinsFile.read().splitlines()
+#if doMissingBinsOnly:
+    #with open(filename) as missingBinsFile:
+        #missingBins = missingBinsFile.read().splitlines()
 
 def getSRcut(nj_bin, lt_bin, sr_bin, blinded):
 


### PR DESCRIPTION
Since it makes no sense to add all the MC and then subtract the TTJets
afterwards using a complicated formula, instead just add the yields of WJets and all
other bkg MC and use the simple N_SR/N_CR formula in the
WJets SB.
The QCD estimation now automatically reads the correct f-ratio file.
The program now requires the year number (2016, 2017 or 2018) to be part
of the pattern or it exists before execution.
This way one can be sure that things work correctly all the time and one
does not have to manually adjust hardcoded input files or replicate the
files for each year.

The change in the searchBins_0b_with_NW.py is just commenting out a few
lines that can be helpful when using the findMissingBins.sh script.
Since they require manual intervention to use anyway, it makes sense to
have them as a comment per default. It is not a meaningful change, just
more conveninet by default.

The run analysis scripts were also updated and should now work again for the 0b.