### PR TITLE
Fix the signal systematics

### DIFF
--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/calcSyst_0b.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/calcSyst_0b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import numpy as np
+#import numpy as np
 import glob, os, sys, math
 from math import hypot
 from ROOT import *
@@ -59,59 +59,29 @@ def getSystHist(tfile, hname, syst = "Xsec"):
         upName = hname + '_' + syst + '-Up'
         dnName = hname + '_' + syst + '-Down'
 
+        #print upName
         hNorm = tfile.Get(hname)
         hUp = tfile.Get(upName)
         hDown = tfile.Get(dnName)
 
-        if not hUp and hDown:
-            # Replace missing Up with Down
-            hUp = hDown
-        elif not hDown and hUp:
-            # Replace missing Down with Up
-            hDown = hUp
-        elif not hUp or not hDown:
-            return (1,2,3)
+        hSyst = hUp.Clone(hNorm.GetName() + '_' + syst + '_syst')
+        hSyst.Add(hDown, -1)
+        hSyst.Divide(hNorm)
+        hSyst.Scale(0.5)
 
+        #xBin = hSyst.GetXaxis().GetBinCenter(225)
+        #yBin = hSyst.GetYaxis().GetBinCenter(225)
+        #print xBin, "/", hSyst.GetXaxis().GetNbins(), yBin,"/", hSyst.GetXaxis().GetNbins(), ":", hSyst.GetBinContent(xBin, yBin)
 
-        hSyst = hNorm.Clone(hNorm.GetName() + '_' + syst + '_syst')
-
-        hUpVar = hNorm.Clone(hNorm.GetName() + '_' + syst + '_upVar')
-        hUpVar.Add(hUp,-1)
-
-        hDownVar = hNorm.Clone(hNorm.GetName() + '_' + syst + '_downVar')
-        hDownVar.Add(hDown,-1)
-
-        # find maximum deviations
-        for xbin in range(1,hSyst.GetNbinsX()+1):
-            for ybin in range(1,hSyst.GetNbinsY()+1):
-
-                # reset bins
-                hSyst.SetBinContent(xbin,ybin,0)
-                hSyst.SetBinError(xbin,ybin,0)
-
-                maxDev = 0
-                maxErr = 0
-
-                #fill with average deviation
-                maxDev = 1/2.*(math.fabs(hUpVar.GetBinContent(xbin,ybin))+math.fabs(hDownVar.GetBinContent(xbin,ybin)))
-
-                if hNorm.GetBinContent(xbin,ybin) > 0:
-                    maxDev /= hNorm.GetBinContent(xbin,ybin)
-
-                # limit max deviation to 200%
-                maxDev = min(maxDev,2.0)
-
-                hSyst.SetBinContent(xbin,ybin,maxDev)
-                hSyst.SetBinError(xbin,ybin,maxErr)
-
-        return (hSyst,hUpVar,hDownVar)
+        return (hSyst,hUp,hDown)
 
 
 def makeSystHists(fileList): #direc,
+    print "Making syst hists"
     if 'signal_' in path:
-	    hnames = ["T5qqqqWW_Scan"] # process name
+        hnames = ["T5qqqqWW_Scan"] # process name
     else:
-        hnames = ['EWK', 'DY', 'QCD', 'SingleT', 'TTJets', 'TTV', 'VV', 'WJets']
+        hnames = ['EWK', 'DY', 'QCD', 'SingleT', 'TTJets', 'TTV', 'VV', 'WJets', 'other_bkg']
 
     # systematic alawys first subdirectory
     print "path =", path
@@ -120,15 +90,23 @@ def makeSystHists(fileList): #direc,
         systNames = [path.split("/")[1].split("_")[1] + "_" + path.split("/")[1].split("_")[2]]
     else:
         systNames = [path.split("/")[1].split("_")[1]]
+    print hnames, systNames
 
     #bindirs =  ['SR_MB','CR_MB','SR_SB','CR_SB']
     #bindirs =  ['SR_MB','CR_MB','SR_SB','CR_SB','Kappa','Rcs_MB','Rcs_SB']
 
     #from IPython import embed;embed()
 
+    #bindirs = []
     bindirs = getDirNames(fileList[0])
-    #print("Found those dirs:", bindirs)
+    print("Found those dirs:", bindirs)
     bindirs = [bin for bin in bindirs if "DL" not in bin]
+    if 'signal_' in path:
+        bindirs = ['SR_MB', 'CR_MB', 'SR_SB', 'CR_SB', 'SR_SB_NB0', 'CR_SB_NB0', 'SR_SB_NB1i', 'CR_SB_NB1i']
+    else:
+        bindirs = ['KappaTT', 'KappaB', 'KappaBTT', 'KappaW', 'SR_MB', 'CR_MB', 'SR_SB', 'CR_SB', 'SR_SB_NB0', 'CR_SB_NB0', 'SR_SB_NB1i', 'CR_SB_NB1i']
+        #bindirs = ['KappaTT', 'KappaB', 'KappaBTT', 'KappaW']
+    print bindirs
 
     #uplist, downlist = GetUpDownList(fileList[0])
     #print(uplist, downlist)
@@ -139,55 +117,38 @@ def makeSystHists(fileList): #direc,
     #from IPython import embed;embed()
 
     for fname in fileList:
-
         tfile = TFile(fname,"UPDATE")
-        #tfile = TFile(fname,"READ")
-        #sysname = sysdir + os.path.basename(fname)
-        #sfile = TFile(sysname,"RECREATE")
 
         for bindir in bindirs:
+            if "syst" in path:
+                if "KappaW" in bindir:
+                    hnames = ['WJets']
+                elif "Kappa" in bindir:
+                    hnames = ['TTJets']
+                else:
+                    hnames = ['EWK', 'DY', 'QCD', 'SingleT', 'TTV', 'VV', 'other_bkg']
+            elif "signal" in path:
+                hnames = ["T5qqqqWW_Scan"] # process name
+            else:
+                print "Something is weird.. Check your path!:\n", path
+                exit()
 
             for hname in hnames:
                 for syst in systNames:
-                    #if "xsec" in syst and "TTJets" in hname and "Kappa" in bindir:
-                    #if "Kappa" in bindir and "xsec" in syst:
-                    #print(bindir, hname, syst)
                     if bindir != "":
                         (hSyst,hUp,hDown) = getSystHist(tfile, bindir+'/'+ hname, syst)
                     else:
                         (hSyst,hUp,hDown) = getSystHist(tfile, hname, syst)
 
-                    #from IPython import embed;embed()
                     if (hSyst,hUp,hDown) == (1,2,3):
                         # this is a kinda hacky way, but it doesn't take to long. If performance is an issue, look here
                         # only the working systematics get included, the rest is passed
                         # so KappaTT for TTJets is working, but all other processes are skipped
                         # Advantage: generalizes the processing, don't have to check for working configurations
                         continue
-
                     if hSyst:
                         tfile.cd(bindir)
-                        #sfile.mkdir(bindir)
-                        #sfile.cd(bindir)
                         hSyst.Write("",TObject.kOverwrite)
-                        #print(hname, syst)
-                        #hUp.Write("",TObject.kOverwrite)
-                        #hDown.Write("",TObject.kOverwrite)
-
-                        #from IPython import embed;embed()
-
-            '''
-            # create Syst folder structure
-            if not tfile.GetDirectory(bindir+"/Syst"):
-            tfile.mkdir(bindir+"/Syst")
-            for hname in hnames:
-            for syst in systNames:
-            tfile.cd(bindir+"/Syst")
-            hSyst = getSystHist(tfile, bindir+'/'+ hname, syst)
-            hSyst.Write()
-            else:
-            print 'Already found syst'
-            '''
 
         tfile.Close()
         #from IPython import embed;embed()
@@ -197,6 +158,7 @@ def combineOtherBkgs(fileList):
     # hardcode MC hists to avoid kappa or repition errors
     bindirs =  ['SR_MB','CR_MB','SR_SB','CR_SB', "SR_SB_NB1i", "CR_SB_NB1i", "SR_SB_NB0", "CR_SB_NB0"]
     other_bkgs = ["DY", "SingleT", "TTV", "VV"]
+    print "Combining other backgrounds"
 
     for fname in fileList:
         tfile = TFile(fname,"UPDATE")
@@ -210,16 +172,28 @@ def combineOtherBkgs(fileList):
             else:
                 systNames = [path.split("/")[1].split("_")[1]]
 
-            assert len(systNames)==1
-            DY_syst = tfile.Get(bind+"/DY_"+systNames[0]+"_syst").Clone()
+            #assert len(systNames)==1
+            DY_nom = tfile.Get(bind+"/DY").Clone()
+            DY_systUp = tfile.Get(bind+"/DY_"+systNames[0]+"-Up").Clone()
+            DY_systDown = tfile.Get(bind+"/DY_"+systNames[0]+"-Down").Clone()
             for other in other_bkgs[1:]:
-                other_syst = tfile.Get(bind+"/{}_{}_syst".format(other,systNames[0])).Clone()
+                otherNominal = tfile.Get(bind+"/{}".format(other)).Clone()
+                other_systUp = tfile.Get(bind+"/{}_{}-Up".format(other,systNames[0])).Clone()
+                other_systDown = tfile.Get(bind+"/{}_{}-Down".format(other,systNames[0])).Clone()
                 #from IPython import embed; embed()
-                DY_syst.Add(other_syst)
+                DY_nom.Add(otherNominal)
+                DY_systUp.Add(other_systUp)
+                DY_systDown.Add(other_systDown)
 
             tfile.cd(bind)
-            DY_syst.SetName("other_bkg_{}_syst".format(systNames[0]))
-            DY_syst.Write("",TObject.kOverwrite)
+            DY_systUp.SetName("other_bkg")
+            DY_systUp.Write("",TObject.kOverwrite)
+            tfile.cd(bind)
+            DY_systUp.SetName("other_bkg_{}-Up".format(systNames[0]))
+            DY_systUp.Write("",TObject.kOverwrite)
+            tfile.cd(bind)
+            DY_systDown.SetName("other_bkg_{}-Down".format(systNames[0]))
+            DY_systDown.Write("",TObject.kOverwrite)
         tfile.Close()
     return 1
 
@@ -235,6 +209,7 @@ if __name__ == "__main__":
 
     if len(sys.argv) > 1:
         pattern = sys.argv[1]
+        pattern = pattern.replace("//", "/")
         print('# pattern is', pattern)
     else:
         print("No pattern given!")
@@ -247,7 +222,6 @@ if __name__ == "__main__":
 
         #print(root, dirs)
         for direc in dirs:
-            #if "signal" in direc:
             if "signal" in direc or "syst" in direc:
                 path = pattern +"/"+ direc
                 for ro,di,fi in os.walk(path):
@@ -261,9 +235,10 @@ if __name__ == "__main__":
                                     if ".root" in file:
                                         fileList.append(path+"/"+file)
 
-                            makeSystHists(fileList)
-
                             if "syst" in direc:
                                 combineOtherBkgs(fileList)
+
+                            makeSystHists(fileList)
+
 
     print('Finished')

--- a/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/readYields.py
+++ b/TTHAnalysis/python/plotter/susy-1lep/RcsDevel/readYields.py
@@ -17,7 +17,7 @@ def getLepYield(hist,leptype = ('lep','sele')):
         return (hist.GetBinContent(1),hist.GetBinError(1))
 
 #    elif hist.GetNbinsX() == 4 and hist.GetNbinsY() == 2:
-    
+
     elif hist.GetNbinsX() <= 5 and hist.GetNbinsY() <= 3:
 
         if leptype == ('mu','anti'):
@@ -71,7 +71,11 @@ def getScanYields(hist,leptype = ('lep','sele')):
                 else:
                     ycnt = ydict[point]
                 if 'syst' in hist.GetName():
-                    ycnt = (ycnt[0] / 2.0, ycnt[1] / 2.0)
+                    #ycnt = (ycnt[0] / 2.0, ycnt[1] / 2.0)
+                    if mupoint in ydict:
+                        ycnt = ((ydict[point][0]**2 + ydict[mupoint][0]**2)**.5, hypot(ydict[point][1], ydict[mupoint][1]))
+                    else:
+                        ycnt = ydict[point]
                 ret[point] = ycnt
 
     elif leptype[0] == 'ele':


### PR DESCRIPTION
The readyields did not properly read out the histograms with "syst" in
their name. Now it add the relative uncertainties in quadrature.
Calcsyst was sped up significantly by just using the functions of the
histogram, instead of doing unnecessary slow loops in python.
The tables for the signal are now written in a simpler way.